### PR TITLE
Supply fan object list excluding Fan:OnOff

### DIFF
--- a/idd/Energy+.idd.in
+++ b/idd/Energy+.idd.in
@@ -33708,7 +33708,7 @@ ZoneHVAC:UnitHeater,
    A6 , \field Supply Air Fan Name
         \required-field
         \type object-list
-        \object-list FansCVandVAV
+        \object-list FansCVandOnOffandVAV
    N1 , \field Maximum Supply Air Flow Rate
         \required-field
         \units m3/s


### PR DESCRIPTION
The field A5 specifies that Fan:OnOff are allowed but field A6 excludes Fan:OnOff from the selection.